### PR TITLE
Load helm-files for using helm-generic-files-map

### DIFF
--- a/helm-project-persist.el
+++ b/helm-project-persist.el
@@ -34,6 +34,7 @@
 ;; requires
 (require 'project-persist)
 (require 'helm)
+(require 'helm-files)
 
 (defvar helm-c-source-project-persist-project-list
   `((name . "Project list")


### PR DESCRIPTION
This fixes following byte-compile warning.

```
helm-project-persist.el:47:16:Warning: reference to free variable
    ‘helm-generic-files-map’
```
